### PR TITLE
adjust symfony sub-package requirements to accept sub-packages from v…

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,13 +17,13 @@
     ],
     "require": {
         "php" : ">=5.3.0",
-        "symfony/filesystem": "v2.7.7"
+        "symfony/filesystem": "~2.7|3.0.*"
     },
     "require-dev": {
         "phpunit/phpunit" : "4.*",
         "scrutinizer/ocular": "~1.1",
         "squizlabs/php_codesniffer": "^2.3",
-        "symfony/yaml": "~2.7",
+        "symfony/yaml": "~2.7|3.0.*",
         "yosymfony/toml": "~0.3",
         "silex/silex": "~2.0@dev",
         "silex/api": "~2.0@dev",
@@ -31,7 +31,7 @@
         "m1/env": "~1.0"
     },
     "suggest": {
-        "symfony/yaml": "~2.7",
+        "symfony/yaml": "~2.7|3.0.*",
         "yosymfony/toml": "~0.3"
     },
     "autoload": {


### PR DESCRIPTION
@m1 

Would be nice if we could add the same require syntax from silex 2 (aka master branch) to accept v3.0.* packages.